### PR TITLE
Make all numbers identical sizes

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -21,6 +21,7 @@ body {
     color: white;
     margin: 0;
     box-sizing: border-box;
+    font-variant-numeric: tabular-nums;
 }
 
 body.loading {


### PR DESCRIPTION
Set font-variant-numeric CSS property to tabular-nums. This should prevent shakiness when numbers are rapidly increasing.

Test:
1. npm install
2. npm run build:esbuild
3. open index.html
4. settings->load from file-> Sample_Saves/May2020.txt
5. Confirm that numbers displayed on 'buildings' tab are of constant width